### PR TITLE
Fix Build

### DIFF
--- a/.github/workflows/build-new.yml
+++ b/.github/workflows/build-new.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyversion: ["cp35-cp35m", "cp36-cp36m", "cp37-cp37m", "cp38-cp38", "cp39-cp39"]
+        pyversion: ["cp36-cp36m", "cp37-cp37m", "cp38-cp38", "cp39-cp39"]
     steps:
     - name: Checkout
       uses: actions/checkout@master

--- a/.github/workflows/build-new.yml
+++ b/.github/workflows/build-new.yml
@@ -11,8 +11,8 @@ on:
     types: [pybind-wrapper]
 
 jobs:
-  build-new:
-    name: New Wrapper Linux Build
+  linux-build:
+    name: Wrapper Linux Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,8 +31,8 @@ jobs:
       with:
         name: gtsam-4.1.1-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
         path: wheelhouse/gtsam-4.1.1-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
-  new-mac-build:
-    name: New Wrapper macOS Build
+  mac-build:
+    name: Wrapper macOS Build
     runs-on: macos-latest
     strategy:
       matrix:

--- a/build-macos-new.sh
+++ b/build-macos-new.sh
@@ -31,7 +31,7 @@ CURRDIR=$(pwd)
 # Build Boost staticly
 mkdir -p boost_build
 cd boost_build
-retry 3 wget https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.gz
+retry 3 wget https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.gz
 tar xzf boost_1_73_0.tar.gz
 cd boost_1_73_0
 ./bootstrap.sh --prefix=$CURRDIR/boost_install --with-libraries=serialization,filesystem,thread,system,atomic,date_time,timer,chrono,program_options,regex clang-darwin

--- a/build-wheels-new.sh
+++ b/build-wheels-new.sh
@@ -7,6 +7,7 @@ git clone https://github.com/borglab/gtsam.git -b prerelease/4.1.1 /gtsam
 
 # Set the build directory
 BUILDDIR="/io/gtsam_build"
+mkdir $BUILDDIR
 cd $BUILDDIR
 
 PYBIN="/opt/python/$PYTHON_VERSION/bin"
@@ -61,6 +62,8 @@ mkdir -p /io/wheelhouse
 cd python
 
 "${PYBIN}/python" setup.py bdist_wheel --python-tag=$PYTHONVER --plat-name=$PLAT
+
+cp ./dist/*.whl /io/wheelhouse/
 
 # Bundle external shared libraries into the wheels
 for whl in ./dist/*.whl; do

--- a/build-wheels-new.sh
+++ b/build-wheels-new.sh
@@ -7,12 +7,6 @@ git clone https://github.com/borglab/gtsam.git -b prerelease/4.1.1 /gtsam
 
 # Set the build directory
 BUILDDIR="/io/gtsam_build"
-
-# FIX auditwheel
-# https://github.com/pypa/auditwheel/issues/136
-echo /opt/_internal/*/*/*/*/auditwheel
-cd /opt/_internal/tools/lib64/python3.7/site-packages/auditwheel
-patch -p2 < /io/auditwheel.txt
 cd $BUILDDIR
 
 PYBIN="/opt/python/$PYTHON_VERSION/bin"
@@ -64,11 +58,9 @@ make -j$(nproc) install
 
 mkdir -p /io/wheelhouse
 
-# "${PYBIN}/pip" wheel . -w "/io/wheelhouse/"
 cd python
 
 "${PYBIN}/python" setup.py bdist_wheel --python-tag=$PYTHONVER --plat-name=$PLAT
-# cp ./dist/*.whl /io/wheelhouse/
 
 # Bundle external shared libraries into the wheels
 for whl in ./dist/*.whl; do
@@ -81,9 +73,3 @@ for whl in /io/wheelhouse/*.whl; do
     new_filename=$(echo $new_filename | sed "s#-none-#-#g")
     mv $whl $new_filename
 done
-
-# Install packages and test
-# for PYBIN in /opt/python/*/bin/; do
-#     "${PYBIN}/pip" install python-manylinux-demo --no-index -f /io/wheelhouse
-#     (cd "$HOME"; "${PYBIN}/nosetests" pymanylinuxdemo)
-# done


### PR DESCRIPTION
The macOS build relies on the old Boost download path which is inaccessible, so let's fix that!

This PR also removes support for Python 3.5.