### PR TITLE
Build 4.2a0

### DIFF
--- a/.github/workflows/build-new.yml
+++ b/.github/workflows/build-new.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Archive wheels
       uses: actions/upload-artifact@v1
       with:
-        name: gtsam-4.1.1-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
-        path: wheelhouse/gtsam-4.1.1-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
+        name: gtsam-4.2a0-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
+        path: wheelhouse/gtsam-4.2a0-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
   mac-build:
     name: Wrapper macOS Build
     runs-on: macos-latest

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Please consult `build-macos.h`.
 
 # Current Build Date
 
-2021-12-21
+2021-12-28
 
-We are building for the 4.1.1 release.
+We are building for the 4.2a0 release.
 
 ## Wheel Update Instructions
 

--- a/build-macos-new.sh
+++ b/build-macos-new.sh
@@ -27,7 +27,7 @@ brew update
 brew install wget python cmake || true
 
 CURRDIR=$(pwd)
-GTSAM_BRANCH="release/4.1.1"
+GTSAM_BRANCH="release/4.2a0"
 
 # Build Boost staticly
 mkdir -p boost_build

--- a/build-wheels-new.sh
+++ b/build-wheels-new.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CURRDIR=$(pwd)
-GTSAM_BRANCH="release/4.1.1"
+GTSAM_BRANCH="release/4.2a0"
 
 # Clone GTSAM
 git clone https://github.com/borglab/gtsam.git -b $GTSAM_BRANCH /gtsam


### PR DESCRIPTION
Build alpha pre-release of GTSAM 4.2, with wrapper for `discrete`, including many API improvements.