### PR TITLE
Switching to alpha 2

### DIFF
--- a/.github/workflows/build-new.yml
+++ b/.github/workflows/build-new.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Archive wheels
       uses: actions/upload-artifact@v1
       with:
-        name: gtsam-4.2a1-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
-        path: wheelhouse/gtsam-4.2a1-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
+        name: gtsam-4.2a2-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
+        path: wheelhouse/gtsam-4.2a2-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
   mac-build:
     name: Wrapper macOS Build
     runs-on: macos-latest

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Please consult `build-macos.h`.
 
 # Current Build Date
 
-2022-01-04
+2022-01-09
 
-We are building for the 4.2a1 release.
+We are building for the 4.2a2 release.
 
 ## Wheel Update Instructions
 

--- a/build-macos-new.sh
+++ b/build-macos-new.sh
@@ -27,7 +27,7 @@ brew update
 brew install wget python cmake || true
 
 CURRDIR=$(pwd)
-GTSAM_BRANCH="release/4.2a1"
+GTSAM_BRANCH="release/4.2a2"
 
 # Build Boost staticly
 mkdir -p boost_build

--- a/build-wheels-new.sh
+++ b/build-wheels-new.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CURRDIR=$(pwd)
-GTSAM_BRANCH="release/4.2a1"
+GTSAM_BRANCH="release/4.2a2"
 
 # Clone GTSAM
 git clone https://github.com/borglab/gtsam.git -b $GTSAM_BRANCH /gtsam


### PR DESCRIPTION
I don't quite understand what you meant, @ProfFan, about not merging these. I probably don't complete understand why this repo exists. It seems that wheels should be built as a Github action in gtsam proper, based on some event, like pushing on a release branch. But today I just want the wheels, fast: I will merge in any changes needed to the "html renderers" PR into the release branch and re-trigger the workflow.