### PR TITLE
Build 4.2a9 wheels

### DIFF
--- a/.github/workflows/build-new.yml
+++ b/.github/workflows/build-new.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Archive wheels
       uses: actions/upload-artifact@v1
       with:
-        name: gtsam-4.2a8-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
-        path: wheelhouse/gtsam-4.2a8-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
+        name: gtsam-4.2a9-${{ matrix.pyversion }}-manylinux2014_x86_64.whl
+        path: wheelhouse/gtsam-4.2a9-${{ matrix.pyversion }}-manylinux2014_x86_64.whl

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Please consult `build-macos.h`.
 
 # Current Build Date
 
-2022-11-29
+2022-01-28
 
-We are building for the 4.2a8 release.
+We are building for the 4.2a9 release.
 
 ## Wheel Update Instructions
 

--- a/build-macos-new.sh
+++ b/build-macos-new.sh
@@ -27,9 +27,9 @@ brew update
 brew install wget "$1" cmake || true
 
 CURRDIR=$(pwd)
-GTSAM_BRANCH="release/4.2a8"
+GTSAM_BRANCH="release/4.2a9"
 GTSAM_LIB_VERSION="4.2.0"
-GTSAM_PYTHON_VERSION="4.2a8"
+GTSAM_PYTHON_VERSION="4.2a9"
 
 # Build Boost staticly
 mkdir -p boost_build

--- a/build-wheels-new.sh
+++ b/build-wheels-new.sh
@@ -3,7 +3,7 @@
 CURRDIR=$(pwd)
 
 # Clone GTSAM
-GTSAM_BRANCH="release/4.2a8"
+GTSAM_BRANCH="release/4.2a9"
 git clone https://github.com/borglab/gtsam.git -b $GTSAM_BRANCH /gtsam
 
 # Set the build directory


### PR DESCRIPTION
Yet another pre-release version as the wrapper is still not entirely stable, as evidenced by https://github.com/gtbook/gtbook/issues/3
