### PR TITLE
Build Python 3.11 Wheels for 4.2.0

### DIFF
--- a/.github/workflows/build-new.yml
+++ b/.github/workflows/build-new.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyversion: ["cp38-cp38", "cp39-cp39", "cp310-cp310"]
+        pyversion: ["cp38-cp38", "cp39-cp39", "cp310-cp310", "cp311-cp311"]
     steps:
     - name: Checkout
       uses: actions/checkout@master

--- a/build-wheels-new.sh
+++ b/build-wheels-new.sh
@@ -4,6 +4,7 @@ CURRDIR=$(pwd)
 
 # Clone GTSAM
 GTSAM_BRANCH="release/4.2"
+echo "Cloning GTSAM with branch $GTSAM_BRANCH"
 git clone https://github.com/borglab/gtsam.git -b $GTSAM_BRANCH /gtsam
 
 # Set the build directory


### PR DESCRIPTION
This PR is meant to build the Python 3.11 wheels for the same commit of GTSAM version 4.2.0 as the other wheels currently on PyPI.

Once the CI builds, and @dellaert uploads the 3.11 wheels to PyPI, this PR will be **closed** (not merged), and the GTSAM repository branch `release/4.2` will be deleted again.

@dellaert adding you as a reviewer for visibility. We will **NOT** merge this PR.